### PR TITLE
feat: add --dry-run flag to preview file moves without executing them

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,73 @@
 # Cleaner
 
-`cleaner` takes a source directory and a target and moves all screenshot files from the source to the target.
+`cleaner` helps you declutter a folder by moving files to a target directory using date-based subfolders. My use case is for removing screenshots from the desktop of my MacOS machine.
 
-To install and use cleaner, you need to have Go >= 1.23.1 installed. Simply run the following command:
+It has two modes:
 
-`go install github.com/ezebunandu/cleaner/cmd/cleaner@latest`
+- **Screenshot mode (default):** moves files that start with `Screenshot`
+- **Extension mode (`-ext`):** recursively moves files by extension (for example `png` or `.png`)
 
-When you take a screenshot on MacOS, it default saves to your desktop with a naming convention like `Screenshot 2023-12-13 at 10.46.37 PM.png`. When you run cleaner, it would declutter your desktop by moving all screenshot files to the target directory and organize them into subfolders by date, making it easy for you to go back and find a particular screenshot, should you need to!
+Moved files are organized as `TARGET/YYYY-MM-DD/`.
+If a filename contains a date like `2024-07-30`, cleaner uses that date.
+Otherwise, it uses the file's modification time.
 
-I have it running as a cron job!.
+## 1) Install
 
-```usage: cleaner <source directory> <target directory>```
+Requires Go `1.23.1+`.
+
+```bash
+go install github.com/ezebunandu/cleaner/cmd/cleaner@latest
+```
+
+## 2) Learn the command
+
+```text
+cleaner [flags] <SOURCE> <TARGET>
+```
+
+Flags:
+
+- `-ext string` match extension (example: `png` or `.png`)
+- `--dry-run` preview matched files without moving anything
+
+If required arguments are missing, cleaner prints usage.
+
+## 3) Try common workflows
+
+### Move screenshots from Desktop
+
+```bash
+cleaner ~/Desktop ~/Pictures/screenshots
+```
+
+### Move all PNG files recursively
+
+```bash
+cleaner -ext png . ./target
+```
+
+### Preview first with dry run
+
+```bash
+cleaner -ext png --dry-run . ./target
+```
+
+Example dry-run output:
+
+```text
+would have moved the following files from . to ./target
+./sample.png
+```
+
+## 4) Know what to expect
+
+- No matches: `no files to move`
+- Success: `moved <N> files to <TARGET>`
+- Dry run: prints source, target, and matched files
+- Errors (missing paths/permissions): printed to stderr and exit non-zero
+
+## 5) Run tests
+
+```bash
+go test ./...
+```

--- a/cleaner.go
+++ b/cleaner.go
@@ -22,6 +22,7 @@ type Cmd struct {
 	Target    string
 	Extension string
 	MatchedFiles []string
+	DryRun bool
 }
 
 func NewCmd() *Cmd {

--- a/cleaner.go
+++ b/cleaner.go
@@ -35,6 +35,7 @@ func CmdFromArgs(args []string) Cmd {
 	}
 	fSet := flag.NewFlagSet("cleaner", flag.ContinueOnError)
 	ext := fSet.String("ext", "", "the file extension to match")
+	dryrun := fSet.Bool("dry-run", false, "enable dry-run mode")
 	err := fSet.Parse(args[1:]) // skip program name so flags like -ext are parsed
 	if err != nil {
 		return Cmd{Operation: CmdUsage}
@@ -43,7 +44,7 @@ func CmdFromArgs(args []string) Cmd {
 	if len(pos) < 2 {
 		return Cmd{Operation: CmdUsage}
 	}
-	return Cmd{Operation: CmdMove, Source: pos[0], Target: pos[1], Extension: *ext}
+	return Cmd{Operation: CmdMove, Source: pos[0], Target: pos[1], Extension: *ext, DryRun: *dryrun}
 }
 
 const usage = `usage: cleaner <SOURCE> <TARGET>`
@@ -160,6 +161,13 @@ func Main() int {
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 1
+	}
+	if cmd.DryRun {
+		fmt.Printf("would have moved the following files from %s to %s\n", cmd.Source, cmd.Target)
+		for _, f := range cmd.MatchedFiles {
+			fmt.Println(f)
+		}
+		return 0
 	}
 	for _, f := range cmd.MatchedFiles {
 		err := MoveFiles(f, cmd.Target)

--- a/cleaner_test.go
+++ b/cleaner_test.go
@@ -41,9 +41,14 @@ func TestCmdFromArgs(t *testing.T) {
 			want: cleaner.Cmd{Operation: cleaner.CmdMove, Source: "source", Target: "target", Extension: "png"},
 		},
 		{
-			desc: "With DryRun Returns Cmd with DryRun",
+			desc: "With DryRun and Ext Flag Returns Cmd with DryRun",
 			args: []string{"cleaner", "-ext", "png", "--dry-run", "source", "target"},
 			want: cleaner.Cmd{Operation: cleaner.CmdMove, Source: "source", Target: "target", Extension: "png", DryRun: true},
+		},
+		{	
+			desc: "With DryRun and No Ext Flag Returns Cmd with DryRun",
+			args: []string{"cleaner", "--dry-run=true", "source", "target"},
+			want: cleaner.Cmd{Operation: cleaner.CmdMove, Source: "source", Target: "target", Extension: "", DryRun: true},
 		},
 	}
 	for _, tC := range testCases {

--- a/cleaner_test.go
+++ b/cleaner_test.go
@@ -40,6 +40,11 @@ func TestCmdFromArgs(t *testing.T) {
 			args: []string{"cleaner", "-ext", "png", "source", "target"},
 			want: cleaner.Cmd{Operation: cleaner.CmdMove, Source: "source", Target: "target", Extension: "png"},
 		},
+		{
+			desc: "With DryRun Returns Cmd with DryRun",
+			args: []string{"cleaner", "-ext", "png", "--dry-run", "source", "target"},
+			want: cleaner.Cmd{Operation: cleaner.CmdMove, Source: "source", Target: "target", Extension: "png", DryRun: true},
+		},
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {

--- a/testdata/testscript/dryrun_prints_matched_files_without_moving.txtar
+++ b/testdata/testscript/dryrun_prints_matched_files_without_moving.txtar
@@ -1,0 +1,8 @@
+mkdir target
+exec touch -t 202602261200 sample.png
+exists sample.txt
+exec cleaner -ext png --dry-run . target
+stdout 'would have moved sample.png to target/2026-02-26'
+exists sample.png
+! exists target/2026-02-26/sample.png
+-- sample.png --

--- a/testdata/testscript/dryrun_prints_matched_files_without_moving.txtar
+++ b/testdata/testscript/dryrun_prints_matched_files_without_moving.txtar
@@ -1,8 +1,9 @@
 mkdir target
 exec touch -t 202602261200 sample.png
-exists sample.txt
 exec cleaner -ext png --dry-run . target
-stdout 'would have moved sample.png to target/2026-02-26'
+stdout 'would have moved the following files from \. to target\n\./sample\.png'
 exists sample.png
 ! exists target/2026-02-26/sample.png
+exists sample.txt
 -- sample.png --
+-- sample.txt --

--- a/testdata/testscript/readonly_target_prints_error.txtar
+++ b/testdata/testscript/readonly_target_prints_error.txtar
@@ -1,4 +1,5 @@
 # Test: Moving screenshots when the target directory is read-only
+[windows] skip 'chmod-based permission test is unix-only'
 mkdir target
 chmod 500 target
 

--- a/todo.md
+++ b/todo.md
@@ -1,5 +1,0 @@
-# To-Dos
-
-- [ ] Enable the user to move all files matching a given extension from the source to the target.
-
-- [ ] Refactor the API to be more abstracted.


### PR DESCRIPTION
Introduces a --dry-run flag that lists matched files that would be moved without actually moving them.

Changes
---------------------
cleaner.go: Adds DryRun bool field to Cmd struct, parses --dry-run flag in CmdFromArgs, and checks the flag in Main before executing file moves
cleaner_test.go: Adds two new test cases for --dry-run flag parsing (combined with -ext and standalone with --dry-run=true syntax)
testdata/testscript/dryrun_prints_matched_files_without_moving.txtar: Adds integration test verifying matched files are printed but not moved, and unmatched files remain untouched
README.md: Updated documentation with structured sections covering install, usage, workflows, expected output, and testing, including the new --dry-run flag and -ext extension mode